### PR TITLE
main: create a basic cli interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = { version = "4.4.6", features = ["derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,13 @@
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    #[arg(short, long)]
+    path: String,
+}
+
 fn main() {
-    println!("Hello, world!");
+    let args = Args::parse();
+    println!("Starting at {}", args.path);
 }


### PR DESCRIPTION
The tool now has a cli interface that accepts a single parameter, path. Path is the base from which the tool will start walking the file system.